### PR TITLE
Update jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,11 +1,18 @@
+// The DataMade Default .jshintrc
+// To customize, check out all available options here:
+// http://jshint.com/docs/options/
+
 {
+  // Set syntax to ES5 (e.g., complain about use of ES6 features)
+  "esversion": 5,
+
   // Put curly braces around conditional blocks & loops
   "curly": true,
 
   // Use deep-equals for comparison
   "eqeqeq": true,
 
-  // Prohibit extension of native objects, i.e., String
+  // Complain about overwriting methods on native objects, i.e., String
   "freeze": true,
 
   // Set max depth of nested blocks
@@ -18,10 +25,11 @@
   "eqnull": true,
 
   // Complain about variables referenced but not defined
-  "undef": true,
+  //
   // n.b. If your variable is defined somewhere else, set globals in
   // your jshintrc (http://jshint.com/docs/options/#globals), or inline
   // (http://jshint.com/docs/#inline-configuration) to quiet this warning
+  "undef": true,
 
   // Complain about variables defined but not referenced
   "unused": true,
@@ -29,7 +37,7 @@
   // Allow variables to be set in conditional blocks and used later
   "funcscope": true,
 
-  // Complain about use of about global variables from jquery
+  // Complain about use of global variables from jquery
   "jquery": true,
 
   // Complain about use of global variables in browsers

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,14 +1,40 @@
 {
-  "curly": true, // Put curly braces around conditional blocks & loops ("Use closures, but don't nest them")
-  "eqeqeq": true, // Use deep-equals for comparison ("Use the === operator")
-  "freeze": true, // Prohibit extension of native objects, i.e., String ("Do not extend built-in prototypes")
-  "maxdepth": 3, // Set max depth of nested blocks ("Use closures, but don't nest them")
-  "maxstatements": 25, // Set max number of statements allowed per function ("Write small functions")
-  "eqnull": true, // Allow comparisons to null
-  "undef": true, // Complain about variables referenced but not defined
-  "unused": true, // Complain about variables defined but not referenced
-  "funcscope": true, // Allow variables to be set in conditional blocks and used later
-  "jquery": true, // Complain about use of about global variables from jquery
-  "browser": true, // Complain about use of global variables in browsers
-  "devel": true // Complain about errant console & alert statements
+  // Put curly braces around conditional blocks & loops
+  "curly": true,
+
+  // Use deep-equals for comparison
+  "eqeqeq": true,
+
+  // Prohibit extension of native objects, i.e., String
+  "freeze": true,
+
+  // Set max depth of nested blocks
+  "maxdepth": 3,
+
+  // Set max number of statements allowed per function
+  "maxstatements": 25,
+
+  // Allow comparisons to null
+  "eqnull": true,
+
+  // Complain about variables referenced but not defined
+  "undef": true,
+  // n.b. If your variable is defined somewhere else, set globals in
+  // your jshintrc (http://jshint.com/docs/options/#globals), or inline
+  // (http://jshint.com/docs/#inline-configuration) to quiet this warning
+
+  // Complain about variables defined but not referenced
+  "unused": true,
+
+  // Allow variables to be set in conditional blocks and used later
+  "funcscope": true,
+
+  // Complain about use of about global variables from jquery
+  "jquery": true,
+
+  // Complain about use of global variables in browsers
+  "browser": true,
+
+  // Complain about errant console & alert statements
+  "devel": true
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,15 +1,14 @@
 {
-  "camelcase": true,
-  "curly": true,
-  "eqeqeq": true,
-  "freeze": true,
-  "indent": 2,
-  "newcap": true,
-  "quotmark": "single",
-  "maxdepth": 3,
-  "maxstatements": 15,
-  "maxlen": 80,
-  "eqnull": true,
-  "funcscope": true,
-  "node": true
+  "curly": true, // Put curly braces around conditional blocks & loops ("Use closures, but don't nest them")
+  "eqeqeq": true, // Use deep-equals for comparison ("Use the === operator")
+  "freeze": true, // Prohibit extension of native objects, i.e., String ("Do not extend built-in prototypes")
+  "maxdepth": 3, // Set max depth of nested blocks ("Use closures, but don't nest them")
+  "maxstatements": 25, // Set max number of statements allowed per function ("Write small functions")
+  "eqnull": true, // Allow comparisons to null
+  "undef": true, // Complain about variables referenced but not defined
+  "unused": true, // Complain about variables defined but not referenced
+  "funcscope": true, // Allow variables to be set in conditional blocks and used later
+  "jquery": true, // Complain about use of about global variables from jquery
+  "browser": true, // Complain about use of global variables in browsers
+  "devel": true // Complain about errant console & alert statements
 }


### PR DESCRIPTION
One question: Do we want to specify ES3, 5, or 6? I think ES5 might be a good idea. We had a stupid bug in Dedupe last summer where a third-party lib [was using an ES6 Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) which wasn't IE compatible... but then again, we might not have caught it, because third-party... Anyway, something to chew on! It's not specified in the styleguide.